### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ txBOM is a Python Twisted package that lets you retrieve forecasts and observati
 
 Use it to integrate non blocking retrieval of Australian Bureau of Meteorology forecasts and observations into your Python Twisted application.
 
-![PyPi version](https://pypip.in/v/txbom/badge.png) &nbsp;&nbsp; ![PyPi version](https://pypip.in/d/txbom/badge.png)
+![PyPi version](https://img.shields.io/pypi/v/txbom.svg &nbsp;&nbsp; ![PyPi version](https://img.shields.io/pypi/dm/txbom.svg
 
 ## Software Dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ txBOM is a Python Twisted package that lets you retrieve forecasts and observati
 
 Use it to integrate non blocking retrieval of Australian Bureau of Meteorology forecasts and observations into your Python Twisted application.
 
-![PyPi version](https://img.shields.io/pypi/v/txbom.svg &nbsp;&nbsp; ![PyPi version](https://img.shields.io/pypi/dm/txbom.svg
+[![PyPi version](https://img.shields.io/pypi/v/txbom.svg)](https://pypi.python.org/pypi/txbom)
 
 ## Software Dependencies
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20txbom))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `txbom`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.